### PR TITLE
Update Docker stuff.

### DIFF
--- a/tests/Dockerfile.windows-x64-base
+++ b/tests/Dockerfile.windows-x64-base
@@ -14,7 +14,7 @@ RUN curl -kL https://raw.github.com/hcarty/ocamlbrew/master/ocamlbrew-install | 
 
 ENV PATH=/home/opam/ocamlbrew/ocaml-4.05.0/bin:$PATH
 
-RUN opam init --auto --compiler=4.04.2
+RUN opam init --auto --compiler=4.06.1
 
 WORKDIR /home/opam/opam-cross-windows
 

--- a/tests/Dockerfile.windows-x64-pretest
+++ b/tests/Dockerfile.windows-x64-pretest
@@ -1,4 +1,4 @@
-FROM ocamlcross/windows-x64-base:latest
+FROM ocamlcross/windows-x64-base:4.06.1
 MAINTAINER Romain Beauxis <toots@rastageeks.org>
 
 USER root

--- a/tests/Dockerfile.windows-x64-pretest
+++ b/tests/Dockerfile.windows-x64-pretest
@@ -1,4 +1,4 @@
-FROM ocamlcross/windows-x64-base:4.04.2
+FROM ocamlcross/windows-x64-base:latest
 MAINTAINER Romain Beauxis <toots@rastageeks.org>
 
 USER root

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -23,7 +23,7 @@ if [ -n "${BUILD_BASE}" ]; then
 fi
 
 # compiler packages are already present in the base image and should never be rebuilt
-SKIPPED="ocaml-windows32.4.04.2 ocaml-windows64.4.04.2 ocaml-windows.4.04.2 conf-gcc-windows64.1"
+SKIPPED="ocaml-windows32.4.06.1 ocaml-windows64.4.06.1 ocaml-windows.4.06.1 conf-gcc-windows64.1"
 # these packages just fail
 SKIPPED="${SKIPPED} lwt-zmq-windows.2.1.0 zmq-windows.4.0-7"
 


### PR DESCRIPTION
This should bring the CI up-to date. Still remaining: building a new docker image and push it. The `gcc` rebuild seems to be stalling on my machine. @whitequark, is the `MXE` update really required here?